### PR TITLE
Add cpp.Int64Map

### DIFF
--- a/std/cpp/Int64Map.hx
+++ b/std/cpp/Int64Map.hx
@@ -1,3 +1,3 @@
 package cpp;
 
-typedef Int64Map<V> = haxe.ds.Int64Map<V>;
+typedef Int64Map<T> = haxe.ds.Int64Map<T>;

--- a/std/cpp/Int64Map.hx
+++ b/std/cpp/Int64Map.hx
@@ -1,0 +1,3 @@
+package cpp;
+
+typedef Int64Map<V> = haxe.ds.Int64Map<V>;


### PR DESCRIPTION
It is removed in haxe 5: https://github.com/HaxeFoundation/haxe/pull/12393/commits/cc6a586d776198bbf7211113d0291e6f586b0698